### PR TITLE
"osx" -> "darwin" in package.json's "os" requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git://github.com/tmarshall/Dribbble-API.git"
     },
-    "os": [ "osx", "linux" ], 
+    "os": [ "darwin", "linux" ], 
     "directories": {  }, 
     "main": "dribbble", 
     "dependencies" : { 


### PR DESCRIPTION
Otherwise (Lion):

```
npm http 200 https://registry.npmjs.org/dribbble-api/-/dribbble-api-0.0.1.tgz
npm ERR! notsup Unsupported
npm ERR! notsup Not compatible with your operating system or architecture: dribbble-api@0.0.1
npm ERR! notsup Valid OS:    osx,linux
npm ERR! notsup Valid Arch:  any
npm ERR! notsup Actual OS:   darwin
npm ERR! notsup Actual Arch: x64

npm ERR! System Darwin 12.2.0
npm ERR! command "node" "/usr/local/bin/npm" "install"
npm ERR! cwd /Users/lefnire/site
npm ERR! node -v v0.8.11
npm ERR! npm -v 1.1.65
npm ERR! code EBADPLATFORM
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /Users/lefnire/site/npm-debug.log
npm ERR! not ok code 0
Tylers-MacBook-Pro-Retina:social-data lefnire$ npm install
npm http GET https://registry.npmjs.org/dribbble-api
npm http 304 https://registry.npmjs.org/dribbble-api
npm ERR! notsup Unsupported
npm ERR! notsup Not compatible with your operating system or architecture: dribbble-api@0.0.1
npm ERR! notsup Valid OS:    osx,linux
npm ERR! notsup Valid Arch:  any
npm ERR! notsup Actual OS:   darwin
npm ERR! notsup Actual Arch: x64

npm ERR! System Darwin 12.2.0
npm ERR! command "node" "/usr/local/bin/npm" "install"
npm ERR! cwd /Users/lefnire/site
npm ERR! node -v v0.8.11
npm ERR! npm -v 1.1.65
npm ERR! code EBADPLATFORM
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!    /Users/lefnire/site/npm-debug.log
npm ERR! not ok code 0
```
